### PR TITLE
Allow include td-agent user to extra groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Controls the Fluentd service options.
 
 A list of Fluentd plugins to install.
 
+    fluentd_user_groups:
+      - adm
+      - syslog
+
+Include td-agent user to extra groups.
+
     fluentd_conf_sources: |
       [see defaults/main.yml for default content]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ fluentd_service_name: td-agent
 fluentd_service_state: started
 fluentd_service_enabled: true
 
+fluentd_user_groups: []
+
 fluentd_plugins:
   - fluent-plugin-elasticsearch
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,14 @@
     user_install: false
   with_items: "{{ fluentd_plugins }}"
 
+- name: Add td-agent user to other groups.
+  user:
+    name: td-agent
+    groups: "{{ item }}"
+    append: yes
+  with_items: "{{ fluentd_user_groups }}"
+  notify: restart fluentd
+
 - name: Start Fluentd.
   service:
     name: "{{ fluentd_service_name }}"


### PR DESCRIPTION
Hello @geerlingguy,

First of all, thanks for this new Ansible role!

I noticed that `td-agent` package creates a new user and group named `td-agent`, and the systemd service runs with this user and group.

The idea of this pull request is to be able to include this new user to other groups in the system to be able to read some logs that haven't read permissions on others.

Thanks.