### PR TITLE
fix(focal) override repository path for focal distribution

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 fluentd_package_state: present
+fluentd_package_dependencies:
+  - apt-transport-https
+  - gnupg2
 
 fluentd_service_name: td-agent
 fluentd_service_state: started

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,9 +1,7 @@
 ---
 - name: Add required dependencies.
   apt:
-    name:
-      - apt-transport-https
-      - gnupg2
+    name: "{{ fluentd_package_dependencies }}"
     state: present
 
 - name: Add td-agent apt key.
@@ -11,11 +9,16 @@
     url: https://packages.treasuredata.com/GPG-KEY-td-agent
     state: present
 
+- name: Override repository path for Focal release.
+  set_fact:
+    override_release_name: "bionic"
+  when: ansible_distribution_release == "focal"
+
 - name: Add td-agent repository.
   apt_repository:
     repo: >-
       deb
-      http://packages.treasuredata.com/3/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/
-      {{ ansible_distribution_release }} contrib
+      https://packages.treasuredata.com/3/{{ ansible_distribution | lower }}/{{ override_release_name | default(ansible_distribution_release) }}/
+      {{ override_release_name | default(ansible_distribution_release) }} contrib
     state: present
     update_cache: true


### PR DESCRIPTION
Treasure Data repository does not have focal specific package, we should have a temporary fix while they push it. 