### PR TITLE
Use td-agent-gem instead of fluent-gem

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Ensure Fluentd plugins are installed.
   gem:
     name: "{{ item.name | default(item) }}"
-    executable: /opt/td-agent/embedded/bin/fluent-gem
+    executable: /usr/sbin/td-agent-gem 
     state: "{{ item.state | default('present') }}"
     version: "{{ item.version | default(omit) }}"
     user_install: false


### PR DESCRIPTION
td-agent-gem must be used instead of fluent-gem:  https://docs.fluentd.org/deployment/plugin-management