### PR TITLE
Allow overwriting yum repo template

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The `td-agent` Fluentd package state; set to `latest` to upgrade or change versi
 
 Controls the Fluentd service options.
 
+    fluentd_yum_repo_template: td.repo.j2
+
+Controls the Fluentd yum repository template used.
+
     fluentd_plugins:
       - fluent-plugin-elasticsearch
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ fluentd_service_name: td-agent
 fluentd_service_state: started
 fluentd_service_enabled: true
 
+fluentd_yum_repo_template: td.repo.j2
+
 fluentd_plugins:
   - fluent-plugin-elasticsearch
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,6 +6,6 @@
 
 - name: Add td-agent repository.
   template:
-    src: td.repo.j2
+    src: "{{ fluentd_yum_repo_template }}"
     dest: /etc/yum.repos.d/td.repo
     mode: 0644


### PR DESCRIPTION
Fixes #9 

In order to have control over yum repository contents, we need to allow overwriting yum repository template for the users.