### PR TITLE
escaping backslashes produced incorrect formatting for URL path

### DIFF
--- a/templates/td.repo.j2
+++ b/templates/td.repo.j2
@@ -1,5 +1,5 @@
 [treasuredata]
 name=TreasureData
-baseurl=http://packages.treasuredata.com/3/redhat/\$releasever/\$basearch
+baseurl=http://packages.treasuredata.com/3/redhat/$releasever/$basearch
 gpgcheck=1
 gpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent


### PR DESCRIPTION
When using ansible-playbook and seeing it fail on td-agent install step analyzed outgoing traffic and realized it was producing 404 trying to reach `https://packages.treasuredata.com/3/redhat/\8/\x86_64_repodata/repomd.xml`
I went into the local deployment of the installed role and modified URL removing backslashes.
It fixed the issue.
**NOTE: Source ansible machine Ubuntu, destination Centos 8 python3 interpreter.**