### PR TITLE
Fix repo in Debian setup tasks

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,9 +13,6 @@
 
 - name: Add td-agent repository.
   apt_repository:
-    repo: >-
-      deb
-      http://packages.treasuredata.com/{{ fluentd_version }}/{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}/
-      {{ ansible_distribution_release | lower }} contrib
+    repo: "deb http://packages.treasuredata.com/{{ fluentd_version }}/{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }} {{ ansible_distribution_release | lower }} contrib"
     state: present
     update_cache: true


### PR DESCRIPTION
In Ubuntu/Debian, the repository is generated incorrectly. The output is something like:

`deb http://packages.treasuredata.com/3/ubuntu/focal/focal contrib`

I have removed the slash between the repo URL and the distribution name. Now it generates correctly:

`deb http://packages.treasuredata.com/3/ubuntu/focal focal contrib`

