### PR TITLE
Add ability to set specific td-agent version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,3 +67,5 @@ fluentd_conf_matches: |
     @type stdout
     @id output_stdout
   </match>
+
+fluentd_package_name: 'td-agent'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Install td-agent.
   package:
-    name: td-agent
+    name: "{{ fluentd_package_name }}"
     state: "{{ fluentd_package_state }}"
 
 - name: Configure Fluentd.


### PR DESCRIPTION
We had some problems regarding the last td-agent version, so a rollback had to be performed.
With this changes, we are able to set up a specific version, using the variable like

fluentd_package_name: 'td-agent=4.2.0-1'
For example.

If not set explicitly, it will use the last one like usual.