### PR TITLE
Allow custom template conf file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ fluentd_service_enabled: true
 fluentd_plugins:
   - fluent-plugin-elasticsearch
 
+fluentd_conf_template: td-agent.conf.j2
+
 fluentd_conf_sources: |
   ## built-in TCP input
   ## @see http://docs.fluentd.org/articles/in_forward

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Configure Fluentd.
   template:
-    src: td-agent.conf.j2
+    src: "{{ fluentd_conf_template }}"
     dest: /etc/td-agent/td-agent.conf
     owner: root
     group: root


### PR DESCRIPTION
I want to use my own conf file instead of the default one provided.

Pretty simple change, I've seen the same feature in other roles you wrote/maintain.

